### PR TITLE
Redmine 3.0.0

### DIFF
--- a/.travis-init.sh
+++ b/.travis-init.sh
@@ -20,7 +20,7 @@ case $REDMINE_VERSION in
           export MIGRATE_PLUGINS=db:migrate_plugins
           export REDMINE_TARBALL=https://github.com/redmine/redmine/archive/$REDMINE_VERSION.tar.gz
           ;;
-  2.*)  export PATH_TO_PLUGINS=./plugins # for redmine 2.0
+  2.* | 3.*)  export PATH_TO_PLUGINS=./plugins # for redmine 2.x and 3.x
           export GENERATE_SECRET=generate_secret_token
           export MIGRATE_PLUGINS=redmine:plugins:migrate
           export REDMINE_TARBALL=https://github.com/redmine/redmine/archive/$REDMINE_VERSION.tar.gz


### PR DESCRIPTION
Redmine 3.0.0 was released. See http://www.redmine.org/news/95 .
This request is to add build for Redmine 3.0.0.
